### PR TITLE
Manwar prc pod document fix

### DIFF
--- a/lib/Plack/Middleware/Session.pm
+++ b/lib/Plack/Middleware/Session.pm
@@ -238,6 +238,10 @@ Tatsuhiko Miyagawa
 
 Stevan Little E<lt>stevan.little@iinteractive.comE<gt>
 
+=head1 REPOSITORY
+
+L<https://github.com/stevan/plack-middleware-session.git>
+
 =head1 COPYRIGHT AND LICENSE
 
 Copyright 2009, 2010 Infinity Interactive, Inc.

--- a/lib/Plack/Middleware/Session/Cookie.pm
+++ b/lib/Plack/Middleware/Session/Cookie.pm
@@ -147,5 +147,14 @@ L<https://github.com/stevan/plack-middleware-session.git>
 
 Rack::Session::Cookie L<Dancer::Session::Cookie>
 
+=head1 COPYRIGHT AND LICENSE
+
+Copyright 2009, 2010 Infinity Interactive, Inc.
+
+L<http://www.iinteractive.com>
+
+This library is free software; you can redistribute it and/or modify
+it under the same terms as Perl itself.
+
 =cut
 

--- a/lib/Plack/Middleware/Session/Cookie.pm
+++ b/lib/Plack/Middleware/Session/Cookie.pm
@@ -1,5 +1,9 @@
 package Plack::Middleware::Session::Cookie;
 use strict;
+
+our $VERSION   = '0.25';
+our $AUTHORITY = 'cpan:STEVAN';
+
 use parent qw(Plack::Middleware::Session);
 
 use Plack::Util::Accessor qw(secret session_key domain expires path secure httponly

--- a/lib/Plack/Middleware/Session/Cookie.pm
+++ b/lib/Plack/Middleware/Session/Cookie.pm
@@ -139,6 +139,10 @@ L<Plack::Session::State::Cookie> for these options.
 
 Tatsuhiko Miyagawa
 
+=head1 REPOSITORY
+
+L<https://github.com/stevan/plack-middleware-session.git>
+
 =head1 SEE ALSO
 
 Rack::Session::Cookie L<Dancer::Session::Cookie>

--- a/lib/Plack/Session.pm
+++ b/lib/Plack/Session.pm
@@ -148,6 +148,10 @@ to cpan-RT.
 
 Stevan Little E<lt>stevan.little@iinteractive.comE<gt>
 
+=head1 REPOSITORY
+
+L<https://github.com/stevan/plack-middleware-session.git>
+
 =head1 COPYRIGHT AND LICENSE
 
 Copyright 2009, 2010 Infinity Interactive, Inc.

--- a/lib/Plack/Session/State.pm
+++ b/lib/Plack/Session/State.pm
@@ -193,6 +193,10 @@ to cpan-RT.
 
 Stevan Little E<lt>stevan.little@iinteractive.comE<gt>
 
+=head1 REPOSITORY
+
+L<https://github.com/stevan/plack-middleware-session.git>
+
 =head1 COPYRIGHT AND LICENSE
 
 Copyright 2009, 2010 Infinity Interactive, Inc.

--- a/lib/Plack/Session/State/Cookie.pm
+++ b/lib/Plack/Session/State/Cookie.pm
@@ -55,10 +55,10 @@ sub finalize {
 sub _set_cookie {
     my($self, $id, $res, %options) = @_;
 
-    my $cookie = bake_cookie( 
+    my $cookie = bake_cookie(
         $self->session_key, {
             value => $id,
-            %options,            
+            %options,
         }
     );
     Plack::Util::header_push($res->[1], 'Set-Cookie', $cookie);
@@ -140,6 +140,10 @@ to cpan-RT.
 =head1 AUTHOR
 
 Stevan Little E<lt>stevan.little@iinteractive.comE<gt>
+
+=head1 REPOSITORY
+
+L<https://github.com/stevan/plack-middleware-session.git>
 
 =head1 COPYRIGHT AND LICENSE
 

--- a/lib/Plack/Session/Store.pm
+++ b/lib/Plack/Session/Store.pm
@@ -109,6 +109,10 @@ to cpan-RT.
 
 Stevan Little E<lt>stevan.little@iinteractive.comE<gt>
 
+=head1 REPOSITORY
+
+L<https://github.com/stevan/plack-middleware-session.git>
+
 =head1 COPYRIGHT AND LICENSE
 
 Copyright 2009, 2010 Infinity Interactive, Inc.

--- a/lib/Plack/Session/Store/Cache.pm
+++ b/lib/Plack/Session/Store/Cache.pm
@@ -101,4 +101,8 @@ to cpan-RT.
 
 Masahiro Chiba
 
+=head1 REPOSITORY
+
+L<https://github.com/stevan/plack-middleware-session.git>
+
 =cut

--- a/lib/Plack/Session/Store/Cache.pm
+++ b/lib/Plack/Session/Store/Cache.pm
@@ -105,4 +105,13 @@ Masahiro Chiba
 
 L<https://github.com/stevan/plack-middleware-session.git>
 
+=head1 COPYRIGHT AND LICENSE
+
+Copyright 2009, 2010 Infinity Interactive, Inc.
+
+L<http://www.iinteractive.com>
+
+This library is free software; you can redistribute it and/or modify
+it under the same terms as Perl itself.
+
 =cut

--- a/lib/Plack/Session/Store/DBI.pm
+++ b/lib/Plack/Session/Store/DBI.pm
@@ -167,7 +167,7 @@ or larger.
 
 =head1 AUTHORS
 
-Many aspects of this module were partially based upon Catalyst::Plugin::Session::Store::DBI
+Many aspects of this module were partially based upon L<Catalyst::Plugin::Session::Store::DBI>
 
 Daisuke Maki
 

--- a/lib/Plack/Session/Store/DBI.pm
+++ b/lib/Plack/Session/Store/DBI.pm
@@ -22,9 +22,9 @@ sub new {
     }
 
     $params{table_name}   ||= 'sessions';
-    $params{serializer}   ||= 
+    $params{serializer}   ||=
         sub { MIME::Base64::encode_base64( Storable::nfreeze( $_[0] ) ) };
-    $params{deserializer} ||= 
+    $params{deserializer} ||=
         sub { Storable::thaw( MIME::Base64::decode_base64( $_[0] ) ) };
 
     my $self = bless { %params }, $class;
@@ -51,7 +51,7 @@ sub store {
     my ($self, $session_id, $session) = @_;
     my $table_name = $self->{table_name};
 
-    # XXX To be honest, I feel like there should be a transaction 
+    # XXX To be honest, I feel like there should be a transaction
     # call here.... but Catalyst didn't have it, so I'm not so sure
 
     my $sth = $self->_dbh->prepare_cached("SELECT 1 FROM $table_name WHERE id = ?");
@@ -59,10 +59,10 @@ sub store {
 
     # need to fetch. on some DBD's execute()'s return status and
     # rows() is not reliable
-    my ($exists) = $sth->fetchrow_array(); 
+    my ($exists) = $sth->fetchrow_array();
 
     $sth->finish;
-    
+
     if ($exists) {
         my $sth = $self->_dbh->prepare_cached("UPDATE $table_name SET session_data = ? WHERE id = ?");
         $sth->execute( $self->serializer->($session), $session_id );
@@ -71,7 +71,7 @@ sub store {
         my $sth = $self->_dbh->prepare_cached("INSERT INTO $table_name (id, session_data) VALUES (?, ?)");
         $sth->execute( $session_id , $self->serializer->($session) );
     }
-    
+
 }
 
 sub remove {
@@ -117,7 +117,7 @@ Plack::Session::Store::DBI - DBI-based session store
           );
       $app;
   };
-  
+
   # with custom serializer/deserializer
 
   builder {
@@ -146,8 +146,8 @@ Plack::Session::Store::DBI - DBI-based session store
 =head1 DESCRIPTION
 
 This implements a DBI based storage for session data. By
-default it will use L<Storable> and L<MIME::Base64> to serialize and 
-deserialize the data, but this can be configured easily. 
+default it will use L<Storable> and L<MIME::Base64> to serialize and
+deserialize the data, but this can be configured easily.
 
 This is a subclass of L<Plack::Session::Store> and implements
 its full interface.
@@ -170,6 +170,10 @@ or larger.
 Many aspects of this module were partially based upon Catalyst::Plugin::Session::Store::DBI
 
 Daisuke Maki
+
+=head1 REPOSITORY
+
+L<https://github.com/stevan/plack-middleware-session.git>
 
 =head1 COPYRIGHT AND LICENSE
 

--- a/lib/Plack/Session/Store/File.pm
+++ b/lib/Plack/Session/Store/File.pm
@@ -99,7 +99,7 @@ Plack::Session::Store::File - Basic file-based session store
 
 This implements a basic file based storage for session data. By
 default it will use L<Storable> to serialize and deserialize the
-data, but this can be configured easily. 
+data, but this can be configured easily.
 
 This is a subclass of L<Plack::Session::Store> and implements
 its full interface.
@@ -143,6 +143,10 @@ to cpan-RT.
 =head1 AUTHOR
 
 Stevan Little E<lt>stevan.little@iinteractive.comE<gt>
+
+=head1 REPOSITORY
+
+L<https://github.com/stevan/plack-middleware-session.git>
 
 =head1 COPYRIGHT AND LICENSE
 

--- a/lib/Plack/Session/Store/Null.pm
+++ b/lib/Plack/Session/Store/Null.pm
@@ -55,6 +55,10 @@ to cpan-RT.
 
 Stevan Little E<lt>stevan.little@iinteractive.comE<gt>
 
+=head1 REPOSITORY
+
+L<https://github.com/stevan/plack-middleware-session.git>
+
 =head1 COPYRIGHT AND LICENSE
 
 Copyright 2009, 2010 Infinity Interactive, Inc.


### PR DESCRIPTION
Hi,

As a part of Pull Request Challenge (initiated by Neil Bowers), I got the distribution plack-middleware-session. I  have forked from the master and then created a branch "MANWAR-PRC-pod-document-fix". The branch contains mainly pod document related fixes. Changes are grouped in 4 individual commits:

commit b829c583d804bc8b9af2229aada9bb0c7be43bfd
commit 9d776c7ed06006392601fa88a7b9e321b891dd74
commit 9359dc77015dfb7177c4c57dfbefa50a702652ec
commit 892ce9bc7868ff39268351b84767d1adf725eb39

One more thing I noticed is that all packages of Plack::Session::* has the $VERSION set to 0.23 except for one package Plack::Session::Store::DBI which is set as 0.10. Does this also need to be same as 0.23?

In my humble opinion, I reckon every package, which is part of "plack-middleware-session" distribution should have the same version i.e. 0.25. What do you think?

Last but not the least, thanks for the great work for the Perl Community.

Best Regards,
Mohammad S Anwar (MANWAR)