### PR TITLE
Add an option to delay session storage until the end of the request

### DIFF
--- a/lib/Plack/Middleware/Session.pm
+++ b/lib/Plack/Middleware/Session.pm
@@ -240,6 +240,40 @@ L<Plack::Session::Store::Cache>.
 
 =back
 
+=head1 PLACK REQUEST OPTIONS
+
+In addition to providing a C<psgix.session> key in C<$env> for
+persistent session information, this module also provides a
+C<psgix.session.options> key which can be used to control the behavior
+of the module per-request.  The following sub-keys exist:
+
+=over
+
+=item I<change_id>
+
+If set to a true value, forces the session identifier to change.  This
+should always be done after logging in, to prevent session fixation
+attacks from subdomains; see
+L<http://en.wikipedia.org/wiki/Session_fixation#Attacks_using_cross-subdomain_cooking>
+
+=item I<expire>
+
+If set to a true value, expunges the session from the store, and clears
+the state in the client.
+
+=item I<no_store>
+
+If set to a true value, no changes made to the session in this request
+will be saved to the store.  Either L</expire> and I</change_id> take
+precedence over this, as both need to update the session store.
+
+=item I<id>
+
+This key contains the session identifier of the session.  It should be
+considered read-only; to generate a new identifier, use L</change_id>.
+
+=back
+
 =head1 BUGS
 
 All complex software has bugs lurking in it, and this module is no

--- a/lib/Plack/Middleware/Session.pm
+++ b/lib/Plack/Middleware/Session.pm
@@ -73,9 +73,7 @@ sub commit {
     my $session = $env->{'psgix.session'};
     my $options = $env->{'psgix.session.options'};
 
-    if ($options->{expire}) {
-        $self->store->remove($options->{id});
-    } elsif ($options->{change_id}) {
+    if ($options->{change_id}) {
         $self->store->remove($options->{id});
         $options->{id} = $self->generate_id($env);
         $self->store->store($options->{id}, $session);
@@ -90,16 +88,17 @@ sub finalize {
     my $session = $env->{'psgix.session'};
     my $options = $env->{'psgix.session.options'};
 
-    $self->commit($env) unless $options->{no_store};
     if ($options->{expire}) {
         $self->expire_session($options->{id}, $res, $env);
     } else {
+        $self->commit($env) unless $options->{no_store};
         $self->save_state($options->{id}, $res, $env);
     }
 }
 
 sub expire_session {
     my($self, $id, $res, $env) = @_;
+    $self->store->remove($id);
     $self->state->expire_session_id($id, $res, $env->{'psgix.session.options'});
 }
 

--- a/lib/Plack/Middleware/Session.pm
+++ b/lib/Plack/Middleware/Session.pm
@@ -73,13 +73,7 @@ sub commit {
     my $session = $env->{'psgix.session'};
     my $options = $env->{'psgix.session.options'};
 
-    if ($options->{change_id}) {
-        $self->store->remove($options->{id});
-        $options->{id} = $self->generate_id($env);
-        $self->store->store($options->{id}, $session);
-    } else {
-        $self->store->store($options->{id}, $session);
-    }
+    $self->store->store($options->{id}, $session);
 }
 
 sub finalize {
@@ -92,8 +86,18 @@ sub finalize {
         $self->expire_session($options->{id}, $res, $env);
     } else {
         $self->commit($env) unless $options->{no_store};
+        $self->change_id($env) if $options->{change_id};
         $self->save_state($options->{id}, $res, $env);
     }
+}
+
+sub change_id {
+    my($self, $env) = @_;
+
+    my $options = $env->{'psgix.session.options'};
+
+    $self->store->remove($options->{id});
+    $options->{id} = $self->generate_id($env);
 }
 
 sub expire_session {

--- a/lib/Plack/Middleware/Session/Cookie.pm
+++ b/lib/Plack/Middleware/Session/Cookie.pm
@@ -66,6 +66,14 @@ sub generate_id {
 
 sub commit { }
 
+sub change_id {
+    my($self, $env) = @_;
+
+    my $options = $env->{'psgix.session.options'};
+
+    $options->{id} = $self->generate_id($env);
+}
+
 sub expire_session {
     my($self, $id, $res, $env) = @_;
     $self->state->expire_session_id($id, $res, $env->{'psgix.session.options'});

--- a/lib/Plack/Middleware/Session/Cookie.pm
+++ b/lib/Plack/Middleware/Session/Cookie.pm
@@ -66,6 +66,11 @@ sub generate_id {
 
 sub commit { }
 
+sub expire_session {
+    my($self, $id, $res, $env) = @_;
+    $self->state->expire_session_id($id, $res, $env->{'psgix.session.options'});
+}
+
 sub save_state {
     my($self, $id, $res, $env) = @_;
 

--- a/lib/Plack/Session/Cleanup.pm
+++ b/lib/Plack/Session/Cleanup.pm
@@ -1,0 +1,57 @@
+package Plack::Session::Cleanup;
+use strict;
+use warnings;
+
+our $VERSION   = '0.23';
+our $AUTHORITY = 'cpan:STEVAN';
+
+sub new {
+    my $class = shift;
+    my $subref = shift;
+    my $self = bless $subref, $class;
+    return $self;
+}
+
+sub DESTROY {
+    my $self = shift;
+    $self->();
+}
+
+1;
+
+__END__
+
+=pod
+
+=head1 NAME
+
+Plack::Session::Cleanup - Run code when the environment is destroyed
+
+=head1 SYNOPSIS
+
+  $env->{'run_at_cleanup'} = Plack::Session::Cleanup->new(
+      sub {
+          # ...
+      }
+  );
+
+
+=head1 DESCRIPTION
+
+This provides a way for L<Plack::Middleware::Session> to run code when
+the environment is cleaned up.
+
+=head1 METHODS
+
+=over 4
+
+=item B<new ( $coderef )>
+
+Executes the given code reference when the object is C<DESTROY>'d.  Care
+should be taken that the given code reference does not close over
+C<$env>, creating a cycle and preventing the C<$env> from being
+destroyed.
+
+=back
+
+=cut

--- a/t/012_streaming.t
+++ b/t/012_streaming.t
@@ -1,28 +1,42 @@
 use strict;
+use File::Temp qw(tempdir);
 use Test::More;
 use Plack::Test;
 use Plack::Middleware::Session;
+use Plack::Session::Store::File;
 use HTTP::Request::Common;
 
 $Plack::Test::Impl = 'Server';
 
-my $app = sub {
+my $base_app = sub {
+    my $env = shift;
     return sub {
         my $respond = shift;
+        $env->{'psgix.session'}->{early} = 1;
         my $w = $respond->([ 200, [ 'Content-Type' => 'text/html' ] ]);
         $w->write("Hello");
+        $env->{'psgix.session'}->{late} = 1;
         $w->close;
     };
 };
 
-$app = Plack::Middleware::Session->wrap($app);
+my $tmp = tempdir(CLEANUP => 1);
 
+my $store = Plack::Session::Store::File->new( dir => $tmp );
+my $app = Plack::Middleware::Session->wrap( $base_app, store => $store);
 test_psgi $app, sub {
     my $cb = shift;
 
     my $res = $cb->(GET "/");
     is $res->content, "Hello";
     like $res->header('Set-Cookie'), qr/plack_session/;
+
+    my ($session_id) = $res->header('Set-Cookie') =~ /plack_session=([a-f0-9]+)/;
+    ok $session_id, "Found session";
+    my $session = $store->fetch($session_id);
+    ok $session, "Fetched session $session_id";
+    ok $session->{early}, "Early data is set";
+    ok $session->{late}, "Late data is set";
 };
 
 done_testing;


### PR DESCRIPTION
By default, state storage currently happens when the header is sent.  If
streaming responses are not in use, this is the same as when the
application has finished running.  However, if the application uses
Plack's streaming responses, its evaluation may not yet be over.  If so,
any session changes afte rthe header has been sent are silently lost.

Add a "late_store" option to delay session storage until the last part
of the response has been sent to the client.  This is done using the
'psgix.cleanup' extension, if supported; otherwise, it is done by
explicitly observing the response stream until it completes.